### PR TITLE
Added code to autocreate empty tracker.js if writable

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -26,8 +26,12 @@ class Controller extends ControllerAdmin
 
         $customJsFile = __DIR__ . '/tracker.js';
 
-        if (!is_writable($customJsFile)) {
-            $notification = new Notification(Piwik::translate('JsTrackerCustom_FileNotWritable', $customJsFile));
+        if (is_writable(__DIR__) && !file_exists($customJsFile)) {
+            file_put_contents($customJsFile, '');
+        }
+
+        if (!is_writable(__DIR__) || !is_writable($customJsFile)) {
+            $notification = new Notification(Piwik::translate('JsTrackerCustom_DirectoryOrFileNotWritable', array(__DIR__, $customJsFile)));
             $notification->context = Notification::CONTEXT_ERROR;
             Notification\Manager::notify('JsTrackerCustom_FileNotWritable', $notification);
         } elseif (($nonce = Common::getRequestVar('customJsNonce', '', 'string')) &&

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,6 +2,7 @@
   "JsTrackerCustom": {
     "JsTrackerCustom": "Custom Tracker JS",
     "AddCustomJs": "Add custom JavaScript code to your piwik.js",
+    "DirectoryOrFileNotWritable": "To be able to add custom JavaScript, the directory %1$s needs to be writable or the file %2$s needs to be writable.",
     "FileNotWritable": "To be able to add custom JavaScript, the file %1$s needs to be writable."
   }
 }


### PR DESCRIPTION
### Description:

Added code to autocreate empty tracker.js if writable
Fixes: #22.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
